### PR TITLE
Feature/update style definition interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1482,6 +1482,7 @@ This interface contains all possible styles that an object can have. This one ex
 * `readonly` relativePosition?: [`IPoint`](#ipoint);
 * `readonly` font?: `string`;
 * `readonly` lineHeight?: `number`;
+* `readonly` characterSpacing?: `number`;
 
 #### ICustomPageSize
 

--- a/README.md
+++ b/README.md
@@ -1481,6 +1481,7 @@ This interface contains all possible styles that an object can have. This one ex
 * `readonly` absolutePosition?: [`IPoint`](#ipoint);
 * `readonly` relativePosition?: [`IPoint`](#ipoint);
 * `readonly` font?: `string`;
+* `readonly` lineHeight?: `number`;
 
 #### ICustomPageSize
 

--- a/src/lib/definitions/style-definition.ts
+++ b/src/lib/definitions/style-definition.ts
@@ -176,4 +176,22 @@ export abstract class StyleDefinition<T extends StyleDefinition<T, I>, I> extend
         this.content.relativePosition = { x, y };
         return this as any;
     }
+
+    /**
+     * Sets the line height, default 1 accroding to [PDFMake documentations](https://pdfmake.github.io/docs/0.1/document-definition-object/styling/#style-properties)
+     * @param height number
+     */
+    public lineHeight(height: number): T {
+        this.content.lineHeight = height;
+        return this as any;
+    }
+
+    /**
+     * Sets size of the letter spacing in pt
+     * @param spacing 
+     */
+    public characterSpacing(spacing: number): T {
+        this.content.characterSpacing = spacing;
+        return this as any;
+    }
 }

--- a/src/lib/interfaces/style-definition.interface.ts
+++ b/src/lib/interfaces/style-definition.interface.ts
@@ -24,4 +24,5 @@ export interface IStyleDefinition extends IContentDefinition {
     readonly absolutePosition?: IPoint;
     readonly relativePosition?: IPoint;
     readonly font?: string;
+    readonly lineHeight?: number;
 }

--- a/src/lib/interfaces/style-definition.interface.ts
+++ b/src/lib/interfaces/style-definition.interface.ts
@@ -25,4 +25,5 @@ export interface IStyleDefinition extends IContentDefinition {
     readonly relativePosition?: IPoint;
     readonly font?: string;
     readonly lineHeight?: number;
+    readonly characterSpacing? :number;
 }

--- a/test/document-definition.spec.ts
+++ b/test/document-definition.spec.ts
@@ -26,7 +26,8 @@ describe('DocumentDefinition', () => {
                 color: '#fefefe',
                 bold: true,
                 fontSize: 15,
-                margin: [10,10,10,10]
+                margin: [10,10,10,10],
+                lineHeight: 1.15,
             },
             footer: 'footer',
             images: {
@@ -63,7 +64,8 @@ describe('DocumentDefinition', () => {
             color: '#fefefe',
             bold: true,
             fontSize: 15,
-            margin: [10,10,10,10]
+            margin: [10,10,10,10],
+            lineHeight: 1.15,
         });
         doc.footer('footer');
         doc.images({

--- a/test/document-definition.spec.ts
+++ b/test/document-definition.spec.ts
@@ -28,6 +28,7 @@ describe('DocumentDefinition', () => {
                 fontSize: 15,
                 margin: [10,10,10,10],
                 lineHeight: 1.15,
+                characterSpacing: 2,
             },
             footer: 'footer',
             images: {
@@ -66,6 +67,7 @@ describe('DocumentDefinition', () => {
             fontSize: 15,
             margin: [10,10,10,10],
             lineHeight: 1.15,
+            characterSpacing:2
         });
         doc.footer('footer');
         doc.images({


### PR DESCRIPTION
add two missing value `lineHeight` & `characterSpacing`

both values tested in my active project which have valid result

---
Before: (`lineHeight` & `characterSpacing` default value )
![image](https://user-images.githubusercontent.com/26329094/104302735-1ece5180-5504-11eb-90f0-9d96a9dfefb4.png)

After (`lineHeight`: 2, `characterSpacing`:1.15)
![image](https://user-images.githubusercontent.com/26329094/104302960-6a80fb00-5504-11eb-8a9d-c7b8bd29531b.png)
